### PR TITLE
Add Argument::PUBLICLY_QUERYABLE to CustomTaxonomy

### DIFF
--- a/src/CustomTaxonomy/Argument.php
+++ b/src/CustomTaxonomy/Argument.php
@@ -33,6 +33,7 @@ class Argument {
 	const LABEL                 = 'label';
 	const LABELS                = 'labels';
 	const IS_PUBLIC             = 'public'; // Inconsistent naming to avoid PHP error.
+	const PUBLICLY_QUERYABLE    = 'publicly_queryable';
 	const SHOW_UI               = 'show_ui';
 	const SHOW_IN_MENU          = 'show_in_menu';
 	const SHOW_IN_NAV_MENUS     = 'show_in_nav_menus';


### PR DESCRIPTION
`publicly_queryable` is a valid argument, see https://codex.wordpress.org/Function_Reference/register_taxonomy#Arguments.

While it is available for `CustomPostType` https://github.com/brightnucleus/custom-content/blob/a8ce0bef84819495bfbaad518cf89acc0854a84c/src/CustomPostType/Argument.php#L38

it's missing for `CustomTaxonomy`.